### PR TITLE
Fixed an issue where the stream/byte[] objects were being GC'd

### DIFF
--- a/ZipTest/Program.cs
+++ b/ZipTest/Program.cs
@@ -83,16 +83,21 @@ namespace ZipTest
 				var text = "Hello World";
 				zip.AddEntry ("/in/archive/data/foo.txt", text, Encoding.UTF8, CompressionMethod.Store);
 
-				using (var fs = File.OpenRead (asmPath)) {
-					zip.AddEntry ("/in/archive/foo/foo.exe", fs, CompressionMethod.Store);
-				}
+				zip.AddEntry ("/in/archive/foo/foo.exe", File.OpenRead (asmPath), CompressionMethod.Store);
 				zip.AddStream (ms, "/in/archive/foo/foo1.txt", method: CompressionMethod.Store);
 			}
 
 			if (File.Exists ("test-archive-write.zip")) {
-				using (var zip = ZipArchive.Open (File.OpenRead ("test-archive-write.zip"))) {
-					foreach (var e in zip) {
-						Console.WriteLine ($" {e.Name} {e.Size} {e.CompressedSize} {e.CompressionMethod}");
+				using (var newzip = ZipArchive.Open ("test-archive-copy.zip", FileMode.Create)) {
+
+					using (var zip = ZipArchive.Open (File.OpenRead ("test-archive-write.zip"))) {
+						foreach (var e in zip) {
+							Console.WriteLine ($" {e.Name} {e.Size} {e.CompressedSize} {e.CompressionMethod}");
+							ms = new MemoryStream ();
+							e.Extract (ms);
+							ms.Position = 0;
+							newzip.AddStream (ms, e.Name, method: CompressionMethod.Store);
+						}
 					}
 				}
 			}


### PR DESCRIPTION
The libzip seems to write most of its data during the close
method call. If a stream or byte[] array has been collected
it can cause problems.

Also the callback seems to be called AFTER the ZipArchive has
been disposed. Which causes a SIGSEGV. So we need to make the
callback static.