### PR TITLE
In the AddFiles method if a path in the archive is NOT provided

### DIFF
--- a/ZipArchive.cs
+++ b/ZipArchive.cs
@@ -429,7 +429,7 @@ namespace Xamarin.Tools.Zip
 				throw new ArgumentNullException (nameof (fileNames));
 
 			foreach (var file in fileNames) {
-				AddFile (file, archivePath: directoryPathInZip);
+				AddFile (file, archivePath: String.IsNullOrEmpty (directoryPathInZip) ? Path.GetFileName (file) : directoryPathInZip);
 			}
 		}
 


### PR DESCRIPTION
we will use just the filename of the file instead.