### PR TITLE
Added Support for loading the 64bit libzip.dll on Windows.

### DIFF
--- a/Native.cs
+++ b/Native.cs
@@ -271,5 +271,18 @@ namespace Xamarin.Tools.Zip
 			}
 			return bitmap;
 		}
+
+		[DllImport ("kernel32.dll", SetLastError = true)]
+		private static extern bool SetDllDirectory (string lpPathName);
+
+		static Native ()
+		{
+			if (Environment.OSVersion.Platform == PlatformID.Win32NT) {
+				string executingDirectory = System.IO.Path.GetDirectoryName (typeof(Native).Assembly.Location);
+				if (Environment.Is64BitProcess) {
+					SetDllDirectory (System.IO.Path.Combine (executingDirectory, "x64"));
+				}
+			}
+		}
 	}
 }


### PR DESCRIPTION
Windows Apps can be either 32 or 64 bit. This commit uses
the

	SetDllDirectory

function to add a new search path to the current search paths
so the correct 64 bit dll can be loaded. In this case it adds
an "x64" directory which is relative to where the LibZipSharp
assembly is.

https://msdn.microsoft.com/en-us/library/ms686203(VS.85).aspx