### PR TITLE
Added some extra info for the GetUnixPermission NotSupported Exception.

### DIFF
--- a/UnixPlatformServices.cs
+++ b/UnixPlatformServices.cs
@@ -159,7 +159,7 @@ namespace Xamarin.Tools.Zip
 				default:
 					// TODO: implement support for the rest of file types
 					// TODO: check what happens if zip with such files is unpacked on Windows
-					throw new NotSupportedException ("Files other than regular ones, directories and symlinks aren't supported yet");
+					throw new NotSupportedException ($"Unsupported Permission {perms}. Files other than regular ones, directories and symlinks aren't supported yet");
 			}
 
 			perms = (UnixExternalPermissions)(xattr & (uint)UnixExternalPermissions.IMODE);


### PR DESCRIPTION
Context https://bugzilla.xamarin.com/show_bug.cgi?id=42360

We need some additional information if we hit this error. So
we can figure out what permission is missing.