### PR TITLE
Fixed an issue where IsDirectory was returning false for directories.

### DIFF
--- a/ZipEntry.cs
+++ b/ZipEntry.cs
@@ -149,7 +149,7 @@ namespace Xamarin.Tools.Zip
 					return (EncryptionMethod)stat.encryption_method;
 				return EncryptionMethod.Unknown;
 			});
-			IsDirectory = Size == 0 && CompressedSize == 0 && FullName.EndsWith ("/", StringComparison.Ordinal);
+			IsDirectory = Size == 0 && FullName.EndsWith ("/", StringComparison.Ordinal);
 			
 			byte opsys;
 			uint xattr;


### PR DESCRIPTION
This is because while the Size is 0 the compressed size
is NOT 0. This is probably because the data has to be stored
somehow in the zip :).

So for directories we'll check that the Size is zero and that
the string ends in a '/'