### PR TITLE
Only read first line to fix errors

### DIFF
--- a/libZipSharp.csproj
+++ b/libZipSharp.csproj
@@ -163,7 +163,7 @@
     <PropertyGroup>
       <_LibZipSonameFilePath>$(IntermediateOutputPath).libZipSoname.txt</_LibZipSonameFilePath>
     </PropertyGroup>
-    <Exec Command="ldconfig -p | grep libzip | tr -d '&#x09;' | cut -d ' ' -f 1 > $(_LibZipSonameFilePath)" />
+    <Exec Command="ldconfig -p | grep libzip | tr -d '&#x09;' | cut -d ' ' -f 1 | head -n 1 > $(_LibZipSonameFilePath)" />
     <ReadLinesFromFile File="$(_LibZipSonameFilePath)">
         <Output TaskParameter="Lines" PropertyName="LibZipSoname" />
     </ReadLinesFromFile>


### PR DESCRIPTION
Only read first line to fix any errors while compiling xamarin.android, because on Arch you have libzip.so and libzip.so.5, it gives 2 lines of output, only take the first one to resolve any 'sed' errors like ```/home/tim/dev/xamarin-android/external/LibZipSharp/libZipSharp.csproj: error : Command 'sed -e 's;@LINUX_SONAME@;libzip.so.5;libzip.so;g' < libZipSharp.dll.config.in > obj/Unix/Debug/libZipSharp.dll.config' exited with code: 1.``` or ```sed: -e expression #1, char 30: unknown option to `s'```