### PR TITLE
[windows] fully support Windows without Mono

### DIFF
--- a/ZipTest/Program.cs
+++ b/ZipTest/Program.cs
@@ -136,7 +136,9 @@ namespace ZipTest
 
 				zip.AddFileToDirectory (asmPath, "first/directory", useFileDirectory: true);
 				zip.AddFileToDirectory (asmPath, "second/directory", useFileDirectory: false);
+#if UNIX
 				zip.AddFileToDirectory ("/usr/bin/zip", "executables", useFileDirectory: false);
+#endif
 				zip.AddFiles (files, useFileDirectories: true);
 				zip.AddFiles (files, useFileDirectories: false);
 				zip.AddFiles (files, "some/directory", true);

--- a/ZipTest/Program.cs
+++ b/ZipTest/Program.cs
@@ -56,7 +56,10 @@ namespace ZipTest
 				Console.WriteLine ($"Number of entries: {zip.EntryCount}");
 				zip.EntryExtract += (object sender, EntryExtractEventArgs e) => {
 					ZipEntry ze = e.Entry;
-					if (e.ProcessedSoFar == 0) {
+					if (Console.IsOutputRedirected) {
+						if (e.ProcessedSoFar == 0)
+							Console.Write ($"{(ze.IsDirectory ? "Directory" : "     File")}: {ze.FullName} {ze.Size} {ze.CompressedSize} {ze.CompressionMethod} {ze.EncryptionMethod} {ze.CRC:X} {ze.ModificationTime} {ze.ExternalAttributes:X}               ");
+					} else if (e.ProcessedSoFar == 0) {
 						Console.Write ($"{(ze.IsDirectory ? "Directory" : "     File")}: {ze.FullName} {ze.Size} {ze.CompressedSize} {ze.CompressionMethod} {ze.EncryptionMethod} {ze.CRC:X} {ze.ModificationTime} {ze.ExternalAttributes:X}               ");
 						cursorLeft = Console.CursorLeft;
 					} else if (e.ProcessedSoFar < ze.Size) {

--- a/ZipTest/ZipTest.csproj
+++ b/ZipTest/ZipTest.csproj
@@ -7,7 +7,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>ZipTest</RootNamespace>
     <AssemblyName>ZipTest</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -35,7 +35,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="Mono.Posix" />
+    <Reference Include="Mono.Posix" Condition=" '$(OS)' == 'Unix'" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Program.cs" />

--- a/ZipTest/ZipTest.csproj
+++ b/ZipTest/ZipTest.csproj
@@ -42,6 +42,16 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
+    <Content Include="..\bin\Windows_NT\$(Configuration)\libzip.dll" Condition=" '$(OS)' == 'Windows_NT'">
+      <Link>libzip.dll</Link>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="..\bin\Windows_NT\$(Configuration)\zlib.dll" Condition=" '$(OS)' == 'Windows_NT'">
+      <Link>zlib.dll</Link>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="..\libZipSharp.csproj">
       <Project>{E248B2CA-303B-4645-ADDC-9D4459D550FD}</Project>
       <Name>libZipSharp</Name>

--- a/libZipSharp.csproj
+++ b/libZipSharp.csproj
@@ -184,6 +184,11 @@
     <Touch Files="$(DllConfigOutputFile)" AlwaysCreate="True" />
   </Target>
 
+  <Target Name="_CopyLibZipForWindows" Condition=" '$(OS)' == 'Windows_NT'">
+    <Copy SourceFiles="$(ProjectDir)packages\libzip.redist.1.1.2.7\build\native\bin\x64\v140\Release\zip.dll" DestinationFiles="$(OutDir)libzip.dll" />
+    <Copy SourceFiles="$(ProjectDir)packages\grpc.dependencies.zlib.redist.1.2.8.10\build\native\bin\v140\x64\Release\dynamic\stdcall\zlib.dll" DestinationFiles="$(OutDir)zlib.dll" />
+  </Target>
+
   <PropertyGroup>
     <BuildDependsOn>
       _DetectUnixOS;
@@ -191,6 +196,7 @@
       _UpdateDllConfigLinux;
       _UpdateDllConfigDarwin;
       _UpdateDllConfigNotUnix;
+      _CopyLibZipForWindows;
       $(BuildDependsOn)
     </BuildDependsOn>
   </PropertyGroup>

--- a/packages.config
+++ b/packages.config
@@ -2,4 +2,6 @@
 <packages>
   <package id="NUnit" version="3.2.0" targetFramework="net45" />
   <package id="NUnit.Engine" version="3.2.0" targetFramework="net45" />
+  <package id="libzip.redist" version="1.1.2.7" />
+  <package id="grpc.dependencies.zlib.redist" version="1.2.8.10" />
 </packages>


### PR DESCRIPTION
As per some of Jon Pryor's suggestions:
- Get `zlib` and `libzip` from NuGet
- Copy these to the `bin` directory, rename `zip.dll` to `libzip.dll`

General Windows fixes for `ZipTest`:
- `Console.Left` was crashing on AppVeyor
- Skip the part compressing `/usr/bin/zip`
- Only reference `Mono.Posix` on Unix
- `TargetFrameworkVersion` has to match `4.5.1`

See a successful build on AppVeyor [here](https://ci.appveyor.com/project/jonathanpeppers/libzipsharp/build/1.0.8). This ran:
```
nuget restore libZipSharp.sln
msbuild libZipSharp.sln
7z a -tzip test.zip *.cs
ZipTest\bin\Debug\ZipTest.exe test.zip
```

Let me know if I need to change anything, thanks.