### PR TITLE
[windows] support for 32 and 64 bit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ Thumbs.db
 *.dotCover
 archives
 libZipSharp.dll.config
+
+#VS 2017
+.vs/

--- a/ZipTest/ZipTest.csproj
+++ b/ZipTest/ZipTest.csproj
@@ -42,12 +42,20 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Content Include="..\bin\Windows_NT\$(Configuration)\libzip.dll" Condition=" '$(OS)' == 'Windows_NT'">
+    <Content Include="..\bin\Windows_NT\$(Configuration)\libzip.dll" Condition=" '$(OS)' == 'Windows_NT' ">
       <Link>libzip.dll</Link>
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
-    <Content Include="..\bin\Windows_NT\$(Configuration)\zlib.dll" Condition=" '$(OS)' == 'Windows_NT'">
+    <Content Include="..\bin\Windows_NT\$(Configuration)\zlib.dll" Condition=" '$(OS)' == 'Windows_NT' ">
       <Link>zlib.dll</Link>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="..\bin\Windows_NT\$(Configuration)\x64\libzip.dll" Condition=" '$(OS)' == 'Windows_NT' ">
+      <Link>x64\libzip.dll</Link>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="..\bin\Windows_NT\$(Configuration)\x64\zlib.dll" Condition=" '$(OS)' == 'Windows_NT' ">
+      <Link>x64\zlib.dll</Link>
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
   </ItemGroup>

--- a/libZipSharp.csproj
+++ b/libZipSharp.csproj
@@ -178,15 +178,17 @@
     <Exec Command="sed -e 's;@LINUX_SONAME@;libzip.so;g' &lt; $(DllConfigInputFile) > $(DllConfigOutputFile)" />
   </Target>
 
-  <Target Name="_UpdateDllConfigNotUnix" Condition=" '$(OS)' != 'Unix'">
+  <Target Name="_UpdateDllConfigNotUnix" Condition=" '$(OS)' != 'Unix' ">
     <!--other platforms such as Windows, could create an empty file-->
     <MakeDir Directories="$(IntermediateOutputPath)" />
     <Touch Files="$(DllConfigOutputFile)" AlwaysCreate="True" />
   </Target>
 
-  <Target Name="_CopyLibZipForWindows" Condition=" '$(OS)' == 'Windows_NT'">
-    <Copy SourceFiles="$(ProjectDir)packages\libzip.redist.1.1.2.7\build\native\bin\x64\v140\Release\zip.dll" DestinationFiles="$(OutDir)libzip.dll" />
-    <Copy SourceFiles="$(ProjectDir)packages\grpc.dependencies.zlib.redist.1.2.8.10\build\native\bin\v140\x64\Release\dynamic\stdcall\zlib.dll" DestinationFiles="$(OutDir)zlib.dll" />
+  <Target Name="_CopyLibZipForWindows" Condition=" '$(OS)' == 'Windows_NT' ">
+    <Copy SourceFiles="$(ProjectDir)packages\libzip.redist.1.1.2.7\build\native\bin\Win32\v140\Release\zip.dll" DestinationFiles="$(OutDir)libzip.dll" />
+    <Copy SourceFiles="$(ProjectDir)packages\grpc.dependencies.zlib.redist.1.2.8.10\build\native\bin\v140\Win32\Release\dynamic\cdecl\zlib.dll" DestinationFiles="$(OutDir)zlib.dll" />
+    <Copy SourceFiles="$(ProjectDir)packages\libzip.redist.1.1.2.7\build\native\bin\x64\v140\Release\zip.dll" DestinationFiles="$(OutDir)x64\libzip.dll" />
+    <Copy SourceFiles="$(ProjectDir)packages\grpc.dependencies.zlib.redist.1.2.8.10\build\native\bin\v140\x64\Release\dynamic\cdecl\zlib.dll" DestinationFiles="$(OutDir)x64\zlib.dll" />
   </Target>
 
   <PropertyGroup>

--- a/libZipSharp.csproj
+++ b/libZipSharp.csproj
@@ -147,7 +147,7 @@
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 
-  <Target Name="_DetectUnixOS" Condition=" '$(OS)' == 'Unix'">
+  <Target Name="_DetectUnixOS" Condition=" '$(OS)' == 'Unix' Or  '$(OS)' == 'Darwin' ">
     <MakeDir Directories="$(IntermediateOutputPath)" />
     <PropertyGroup>
       <_UnixFlavorFilePath>$(IntermediateOutputPath).unixFlavor.txt</_UnixFlavorFilePath>


### PR DESCRIPTION
Windows:
- Put 32 bit dlls in `bin` and 64 in `bin\x64`
- Should use `cdecl` version of zlib instead of `stdcall`
- VS 2017 gitignore

MacOS:
* Fix for #22 breaking the build on MacOS, when I bumped LibZipSharp in Xamarin.Android

AppVeyor build: https://ci.appveyor.com/project/jonathanpeppers/libzipsharp/build/1.0.10