### PR TITLE
[windows] better implementation for NuGet files

### DIFF
--- a/libZipSharp.csproj
+++ b/libZipSharp.csproj
@@ -136,8 +136,24 @@
     <DllConfigInputFile>$(DllConfigOutputFileName).in</DllConfigInputFile>
   </PropertyGroup>
   <ItemGroup>
-    <Content Include="$(DllConfigOutputFile)">
+    <Content Include="$(DllConfigOutputFile)" Condition=" '$(OS)' != 'Windows_NT' ">
       <Link>$(DllConfigOutputFileName)</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="packages\libzip.redist.1.1.2.7\build\native\bin\Win32\v140\Release\zip.dll" Condition=" '$(OS)' == 'Windows_NT' ">
+      <Link>libzip.dll</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="packages\grpc.dependencies.zlib.redist.1.2.8.10\build\native\bin\v140\Win32\Release\dynamic\cdecl\zlib.dll" Condition=" '$(OS)' == 'Windows_NT' ">
+      <Link>zlib.dll</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="packages\libzip.redist.1.1.2.7\build\native\bin\x64\v140\Release\zip.dll" Condition=" '$(OS)' == 'Windows_NT' ">
+      <Link>x64\libzip.dll</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="packages\grpc.dependencies.zlib.redist.1.2.8.10\build\native\bin\v140\x64\Release\dynamic\cdecl\zlib.dll" Condition=" '$(OS)' == 'Windows_NT' ">
+      <Link>x64\zlib.dll</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
@@ -178,27 +194,12 @@
     <Exec Command="sed -e 's;@LINUX_SONAME@;libzip.so;g' &lt; $(DllConfigInputFile) > $(DllConfigOutputFile)" />
   </Target>
 
-  <Target Name="_UpdateDllConfigNotUnix" Condition=" '$(OS)' != 'Unix' ">
-    <!--other platforms such as Windows, could create an empty file-->
-    <MakeDir Directories="$(IntermediateOutputPath)" />
-    <Touch Files="$(DllConfigOutputFile)" AlwaysCreate="True" />
-  </Target>
-
-  <Target Name="_CopyLibZipForWindows" Condition=" '$(OS)' == 'Windows_NT' ">
-    <Copy SourceFiles="$(ProjectDir)packages\libzip.redist.1.1.2.7\build\native\bin\Win32\v140\Release\zip.dll" DestinationFiles="$(OutDir)libzip.dll" />
-    <Copy SourceFiles="$(ProjectDir)packages\grpc.dependencies.zlib.redist.1.2.8.10\build\native\bin\v140\Win32\Release\dynamic\cdecl\zlib.dll" DestinationFiles="$(OutDir)zlib.dll" />
-    <Copy SourceFiles="$(ProjectDir)packages\libzip.redist.1.1.2.7\build\native\bin\x64\v140\Release\zip.dll" DestinationFiles="$(OutDir)x64\libzip.dll" />
-    <Copy SourceFiles="$(ProjectDir)packages\grpc.dependencies.zlib.redist.1.2.8.10\build\native\bin\v140\x64\Release\dynamic\cdecl\zlib.dll" DestinationFiles="$(OutDir)x64\zlib.dll" />
-  </Target>
-
   <PropertyGroup>
     <BuildDependsOn>
       _DetectUnixOS;
       _GetLibZipNameLinux;
       _UpdateDllConfigLinux;
       _UpdateDllConfigDarwin;
-      _UpdateDllConfigNotUnix;
-      _CopyLibZipForWindows;
       $(BuildDependsOn)
     </BuildDependsOn>
   </PropertyGroup>


### PR DESCRIPTION
My previous implementation of Windows/NuGet had some issues:
- The `<Copy />` tasks can cause double writes (only a perf issue)
- If using `libZipSharp.csproj` as a `<ProjectReference />`, the NuGet
dlls are not copied to the other project's output directory
- I was using the `<Touch />` task to create an empty file

I now have alot more MSBuild knowledge, changes include:
- Just make `$(DllConfigOutputFile)` conditional, we can remove the
`_UpdateDllConfigNotUnix` target
- Use `<Content />` and `CopyToOutputDirectory` to fix
`<ProjectReference />` in other projects

Successful Windows build on AppVeyor [here](https://ci.appveyor.com/project/jonathanpeppers/libzipsharp/build/1.0.13).