### PR TITLE
Dispose ZipArchive.sources

### DIFF
--- a/ZipArchive.cs
+++ b/ZipArchive.cs
@@ -44,7 +44,7 @@ namespace Xamarin.Tools.Zip
 
 		IntPtr          archive = IntPtr.Zero;
 		bool            disposed;
-		HashSet<object> sources = new HashSet<object> ();
+		HashSet<IDisposable>    sources = new HashSet<IDisposable> ();
 		static Native.zip_source_callback callback = new Native.zip_source_callback (stream_callback);
 
 		internal IntPtr ArchivePointer {
@@ -807,6 +807,9 @@ namespace Xamarin.Tools.Zip
 				return;
 
 			Native.zip_close (archive);
+			foreach (var s in sources) {
+				s.Dispose ();
+			}
 			sources.Clear ();
 			archive = IntPtr.Zero;
 		}


### PR DESCRIPTION
On Xamarin.Android 8.1 on Windows, we are experiencing problems with
file sharing causing build errors

        error while writing anim: obj\Debug\android\bin\classes\android\support\design\R$anim.class (The process cannot access the file because it is being used by another process)

Our current theory is that the `FileStream` instances created by
`ZipArchive.AddFile()` and stored in `ZipArchive.sources` is keeping
the files open longer than necessary, and the `GC.Collect()` within
`ZipArchiveEx.Flush()` doesn't adequately ensure that the `FileStream`
instances are closed.

Change `ZipArchive.sources` to be a `HashSet<IDisposable>`, and call
`Dispose()` on each of those stream instances within
`ZipArchive.Close()`. This should ensure that the referenced
`FileStream` instances are disposed in a reasonable manner, without
keeping the files open for unknown periods of time.