### PR TITLE
[windows] remove NuGets for libzip and zlib

### DIFF
--- a/ZipTest/ZipTest.csproj
+++ b/ZipTest/ZipTest.csproj
@@ -42,24 +42,6 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Content Include="..\bin\Windows_NT\$(Configuration)\libzip.dll" Condition=" '$(OS)' == 'Windows_NT' ">
-      <Link>libzip.dll</Link>
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-    <Content Include="..\bin\Windows_NT\$(Configuration)\zlib.dll" Condition=" '$(OS)' == 'Windows_NT' ">
-      <Link>zlib.dll</Link>
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-    <Content Include="..\bin\Windows_NT\$(Configuration)\x64\libzip.dll" Condition=" '$(OS)' == 'Windows_NT' ">
-      <Link>x64\libzip.dll</Link>
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-    <Content Include="..\bin\Windows_NT\$(Configuration)\x64\zlib.dll" Condition=" '$(OS)' == 'Windows_NT' ">
-      <Link>x64\zlib.dll</Link>
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="..\libZipSharp.csproj">
       <Project>{E248B2CA-303B-4645-ADDC-9D4459D550FD}</Project>
       <Name>libZipSharp</Name>

--- a/libZipSharp.csproj
+++ b/libZipSharp.csproj
@@ -126,36 +126,12 @@
     <Folder Include="x64\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="grpc.dependencies.zlib.redist" GeneratePathProperty="true">
-      <Version>1.2.8.10</Version>
-    </PackageReference>
-    <PackageReference Include="libzip.redist" GeneratePathProperty="true">
-      <Version>1.1.2.7</Version>
-    </PackageReference>
     <PackageReference Include="NUnit">
       <Version>3.11.0</Version>
     </PackageReference>
     <PackageReference Include="NUnit.Engine">
       <Version>3.9.0</Version>
     </PackageReference>
-  </ItemGroup>
-  <ItemGroup>
-    <Content Include="$(Pkglibzip_redist)\build\native\bin\Win32\v140\Release\zip.dll" Condition=" '$(OS)' == 'Windows_NT' ">
-      <Link>libzip.dll</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="$(Pkggrpc_dependencies_zlib_redist)\build\native\bin\v140\Win32\Release\dynamic\cdecl\zlib.dll" Condition=" '$(OS)' == 'Windows_NT' ">
-      <Link>zlib.dll</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="$(Pkglibzip_redist)\build\native\bin\x64\v140\Release\zip.dll" Condition=" '$(OS)' == 'Windows_NT' ">
-      <Link>x64\libzip.dll</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="$(Pkggrpc_dependencies_zlib_redist)\build\native\bin\v140\x64\Release\dynamic\cdecl\zlib.dll" Condition=" '$(OS)' == 'Windows_NT' ">
-      <Link>x64\zlib.dll</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Target Name="_DetectUnixOS" Condition=" '$(OS)' == 'Unix' Or  '$(OS)' == 'Darwin' ">


### PR DESCRIPTION
The NuGets we were using on Windows:

* Are quite old
* Appear to not work for 32-bit processes

xamarin/xamarin-android builds its own copy of these native libraries,
but in some cases `libZipSharp.csproj` was overwriting them.

We think it's better to just remove these NuGet references for Windows
here, since we are not supplying the native libraries for the other
platforms.